### PR TITLE
Update a deprecated value of the AdPosition Enum

### DIFF
--- a/openrtb-core/src/main/protobuf/openrtb.proto
+++ b/openrtb-core/src/main/protobuf/openrtb.proto
@@ -2494,10 +2494,7 @@ enum AdPosition {
 
   ABOVE_THE_FOLD = 1;
 
-  // May or may not be immediately visible depending on screen size and
-  // resolution.
-  // @deprecated
-  DEPRECATED_LIKELY_BELOW_THE_FOLD = 2;
+  LOCKED = 2;
 
   BELOW_THE_FOLD = 3;
 


### PR DESCRIPTION
The Placement Enum has been updated!

<img width="1264" height="573" alt="image" src="https://github.com/user-attachments/assets/c4aaf54e-14c8-49e2-97ac-fbcdc99577be" />
